### PR TITLE
fix(security): make seed mutations internal

### DIFF
--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -1,4 +1,4 @@
-import { mutation, query } from './_generated/server'
+import { internalMutation, internalQuery } from './_generated/server'
 import { authTables } from '@convex-dev/auth/server'
 
 // Predefined categories for work expenses
@@ -11,7 +11,7 @@ const PREDEFINED_CATEGORIES = [
 /**
  * Seed the predefined categories if they don't exist
  */
-export const seedCategories = mutation({
+export const seedCategories = internalMutation({
   args: {},
   handler: async (ctx) => {
     // Check if predefined categories already exist
@@ -40,7 +40,7 @@ export const seedCategories = mutation({
 /**
  * Check if categories are seeded
  */
-export const checkSeeded = query({
+export const checkSeeded = internalQuery({
   args: {},
   handler: async (ctx) => {
     const categories = await ctx.db
@@ -63,7 +63,7 @@ export const checkSeeded = query({
  * Seed data for E2E tests
  * Creates predefined categories if they don't exist
  */
-export const e2e = mutation({
+export const e2e = internalMutation({
   args: {},
   handler: async (ctx) => {
     // First, seed the predefined categories
@@ -91,7 +91,7 @@ export const e2e = mutation({
  * Removes expenses, user-created categories, and all auth-related records.
  * Predefined categories are preserved so the next seed is a no-op.
  */
-export const cleanup = mutation({
+export const cleanup = internalMutation({
   args: {},
   handler: async (ctx) => {
     // Delete all expenses (and their attachments)


### PR DESCRIPTION
## Summary
- Convert `seedCategories`, `e2e`, `cleanup` from `mutation` to `internalMutation`
- Convert `checkSeeded` from `query` to `internalQuery`
- These functions were publicly callable without authentication, allowing anyone to wipe the entire database

The `convex run` CLI can still invoke internal functions, so all scripts and CI workflows work unchanged.

## Test plan
- [ ] `pnpm test:e2e:seed` still seeds data successfully
- [ ] `pnpm test:e2e:cleanup` still cleans up data
- [ ] Verify the functions are no longer callable from client-side code
- [ ] CI E2E tests pass

Fixes #33

Made with [Cursor](https://cursor.com)