### PR TITLE
fix(security): verify category ownership in expense create/update

### DIFF
--- a/convex/categories.ts
+++ b/convex/categories.ts
@@ -1,6 +1,27 @@
 import { v } from 'convex/values'
+import type { QueryCtx } from './_generated/server'
 import { mutation, query } from './_generated/server'
+import type { Id } from './_generated/dataModel'
 import { auth } from './auth'
+
+/**
+ * Verify that a category is accessible to the given user.
+ * A category is accessible if it is predefined (no userId) or owned by the user.
+ * Throws if the category doesn't exist or belongs to another user.
+ */
+export async function verifyCategoryAccess(
+  ctx: { db: QueryCtx['db'] },
+  categoryId: Id<'categories'>,
+  userId: Id<'users'>,
+) {
+  const category = await ctx.db.get(categoryId)
+  if (!category) {
+    throw new Error('Category not found')
+  }
+  if (category.userId !== undefined && category.userId !== userId) {
+    throw new Error('Category not found')
+  }
+}
 
 /**
  * List all categories (predefined + user's custom)

--- a/convex/expenses.ts
+++ b/convex/expenses.ts
@@ -1,6 +1,7 @@
 import { v } from 'convex/values'
 import { mutation, query } from './_generated/server'
 import { auth } from './auth'
+import { verifyCategoryAccess } from './categories'
 import { verifyAttachmentOwnership, deleteUploadRecord } from './storage'
 import { validateExpenseFields } from './validation'
 
@@ -97,6 +98,7 @@ export const create = mutation({
     }
 
     validateExpenseFields(args)
+    await verifyCategoryAccess(ctx, args.categoryId, userId)
 
     // Verify the user owns the uploaded file
     if (args.attachmentId) {
@@ -144,6 +146,7 @@ export const update = mutation({
     }
 
     validateExpenseFields(args)
+    await verifyCategoryAccess(ctx, args.categoryId, userId)
 
     // If the attachment is changing, verify the user owns the new upload
     if (args.attachmentId && args.attachmentId !== existing.attachmentId) {


### PR DESCRIPTION
## Summary
- Add `verifyCategoryAccess` helper in `categories.ts` that checks a category is predefined or owned by the current user
- Call it in both `expenses.create` and `expenses.update` before saving
- Prevents users from associating expenses with another user's custom categories

## Test plan
- [ ] Creating an expense with a valid predefined category works
- [ ] Creating an expense with the user's own custom category works
- [ ] Creating an expense with another user's custom category is rejected
- [ ] Editing an expense to change category works with valid categories

Fixes #34

Made with [Cursor](https://cursor.com)