### PR TITLE
fix: add try/catch for attachment deletion in seed cleanup

### DIFF
--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -98,7 +98,11 @@ export const cleanup = mutation({
     const expenses = await ctx.db.query('expenses').collect()
     for (const expense of expenses) {
       if (expense.attachmentId) {
-        await ctx.storage.delete(expense.attachmentId)
+        try {
+          await ctx.storage.delete(expense.attachmentId)
+        } catch {
+          // File may have already been deleted
+        }
       }
       await ctx.db.delete(expense._id)
     }


### PR DESCRIPTION
## Summary

- Wraps `ctx.storage.delete(expense.attachmentId)` in a try/catch inside the `cleanup` mutation's expense loop, so the entire cleanup no longer aborts if a storage file is already gone.
- Matches the existing pattern used in the uploads cleanup loop just below.

Fixes #36

## Test plan

- [ ] Run the `cleanup` mutation when all storage files exist — should succeed as before.
- [ ] Run the `cleanup` mutation after manually deleting a storage file — should now complete without throwing.

Made with [Cursor](https://cursor.com)