### PR TITLE
fix(ci): use global concurrency group for E2E tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,8 +8,8 @@ env:
   VITE_CONVEX_URL: ${{ secrets.CONVEX_TEST_URL }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: e2e-convex-test-deploy
+  cancel-in-progress: false
 
 jobs:
   e2e:


### PR DESCRIPTION
## Summary

Changes the E2E workflow concurrency group from per-branch (`${{ github.workflow }}-${{ github.ref }}`) to a global group (`e2e-convex-test-deploy`), and disables `cancel-in-progress`. This prevents concurrent PRs from deploying conflicting Convex schemas to the shared test project — workflows now queue instead of racing.

Tradeoff: E2E tests for different PRs run sequentially instead of in parallel. For this project's scale, that's acceptable.

Closes #82

## Test plan

- [ ] Open two PRs simultaneously with Convex changes; verify the second E2E run queues until the first completes

Made with [Cursor](https://cursor.com)