### PR TITLE
fix: remove duplicate error feedback in auth forms

### DIFF
--- a/src/routes/_auth/forgot-password.tsx
+++ b/src/routes/_auth/forgot-password.tsx
@@ -181,7 +181,6 @@ function CodeStep({
             ? 'Code is invalid or expired. Please request a new one.'
             : 'Error resetting password. Please try again.'
         setServerError(message)
-        toast.error(message)
       }
     },
   })

--- a/src/routes/_auth/sign-in.tsx
+++ b/src/routes/_auth/sign-in.tsx
@@ -56,7 +56,6 @@ function SignInPage() {
       } catch (error) {
         console.error('Sign in error:', error)
         setServerError('Invalid email or password')
-        toast.error('Invalid email or password')
       }
     },
   })

--- a/src/routes/_auth/sign-up.tsx
+++ b/src/routes/_auth/sign-up.tsx
@@ -63,7 +63,6 @@ function SignUpPage() {
             ? 'An account with this email already exists. Try signing in instead.'
             : 'Error during registration. Please try again.'
         setServerError(message)
-        toast.error(message)
       }
     },
   })


### PR DESCRIPTION
## Summary

Auth forms (sign-in, sign-up, forgot-password) previously showed server-side errors in two places simultaneously: an inline `FieldError` message AND a toast notification. This is redundant and can confuse users.

Removed the `toast.error()` calls from error handlers, keeping only the inline error display. Success toasts (sign-in, sign-up, password reset) are preserved since they provide useful feedback before navigation.

### Why inline-only (deviation from original issue proposal)

Issue #102 originally proposed toast-only for server errors. After review, inline-only is the better UX:

1. **Persistence** — inline errors stay visible until the user acts. Toasts auto-dismiss and can be missed.
2. **Context** — the error appears right where the user needs to correct input.
3. **Accessibility** — `FieldError` uses `role="alert"` (implicit ARIA live region), so screen readers announce the error automatically.
4. **Simplicity** — one feedback channel is easier to reason about.

Issue #102 has been updated to reflect this revised strategy.

## Test plan

- [x] `pnpm lint` — no lint errors
- [x] `pnpm build` — clean build (includes `tsc --noEmit`)
- [x] `pnpm test:unit` — all tests pass
- [x] `pnpm test:visual:docker` — no visual regressions
- [ ] CI: e2e tests pass (runs against deployed preview)
- [x] Manual: sign-in with wrong credentials shows inline error only (no toast)
- [x] Manual: sign-up with existing email shows inline error only (no toast)
- [x] Manual: invalid reset code shows inline error only (no toast)
- [x] Manual: success cases still show toast notifications

Closes #102