### PR TITLE
feat: add attachment preview hovercard to dashboard table

### DIFF
--- a/src/components/expense-form.tsx
+++ b/src/components/expense-form.tsx
@@ -158,7 +158,7 @@ function AttachmentPreview({ attachmentId }: { attachmentId: Id<'_storage'> }) {
           rel="noopener noreferrer"
           className="text-primary inline-flex items-center gap-2 text-sm hover:underline"
         >
-          <span aria-hidden="true">📄</span> View PDF attachment
+          <span aria-hidden="true">📄</span> View attachment
         </a>
       )}
     </div>

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { PreviewCard as PreviewCardPrimitive } from '@base-ui/react/preview-card'
+
+import { cn } from '@/lib/utils'
+
+function HoverCard({ ...props }: PreviewCardPrimitive.Root.Props) {
+  return <PreviewCardPrimitive.Root data-slot="hover-card" {...props} />
+}
+
+function HoverCardTrigger({ ...props }: PreviewCardPrimitive.Trigger.Props) {
+  return <PreviewCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+}
+
+function HoverCardContent({
+  className,
+  side = 'bottom',
+  sideOffset = 4,
+  align = 'center',
+  alignOffset = 4,
+  ...props
+}: PreviewCardPrimitive.Popup.Props &
+  Pick<PreviewCardPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset'>) {
+  return (
+    <PreviewCardPrimitive.Portal data-slot="hover-card-portal">
+      <PreviewCardPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PreviewCardPrimitive.Popup
+          data-slot="hover-card-content"
+          className={cn(
+            'bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 w-64 origin-(--transform-origin) rounded-lg p-2.5 text-sm shadow-md ring-1 outline-hidden duration-100',
+            className,
+          )}
+          {...props}
+        />
+      </PreviewCardPrimitive.Positioner>
+    </PreviewCardPrimitive.Portal>
+  )
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/src/routes/_authenticated/dashboard.tsx
+++ b/src/routes/_authenticated/dashboard.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useSuspenseQuery, useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { convexQuery, useConvexMutation } from '@convex-dev/react-query'
 import { api } from '../../../convex/_generated/api'
 import { Button } from '@/components/ui/button'
@@ -30,6 +30,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { formatCurrency, formatDate } from '@/lib/format'
 import { toast } from 'sonner'
 import { Suspense, useMemo, useState, useTransition } from 'react'
@@ -210,10 +211,7 @@ function ExpenseTable() {
                 </TableCell>
                 <TableCell>
                   {expense.attachmentId ? (
-                    <>
-                      <span aria-hidden="true">📎</span>
-                      <span className="sr-only">Has attachment</span>
-                    </>
+                    <AttachmentHoverCard storageId={expense.attachmentId} />
                   ) : (
                     '-'
                   )}
@@ -331,6 +329,80 @@ function ExpenseTable() {
           )}
         </nav>
       )}
+    </div>
+  )
+}
+
+function AttachmentHoverCard({ storageId }: { storageId: Id<'_storage'> }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const { data: url, isLoading } = useQuery({
+    ...convexQuery(api.storage.getUrl, { storageId }),
+    enabled: isOpen,
+    // storage.getUrl returns a temporary signed URL — override Convex's
+    // default staleTime (Infinity) so cached URLs are refreshed before
+    // they expire.
+    staleTime: 5 * 60 * 1000,
+  })
+
+  return (
+    <HoverCard open={isOpen} onOpenChange={setIsOpen}>
+      <HoverCardTrigger
+        delay={200}
+        closeDelay={150}
+        render={<button type="button" className="cursor-default border-0 bg-transparent p-0" />}
+      >
+        <span aria-hidden="true">📎</span>
+        <span className="sr-only">Has attachment</span>
+      </HoverCardTrigger>
+      {isOpen && (
+        <HoverCardContent className="w-auto max-w-[220px] p-2" side="top" sideOffset={8}>
+          <AttachmentPreviewContent url={url} isLoading={isLoading} />
+        </HoverCardContent>
+      )}
+    </HoverCard>
+  )
+}
+
+function AttachmentPreviewContent({
+  url,
+  isLoading,
+}: {
+  url: string | null | undefined
+  isLoading: boolean
+}) {
+  const [failedUrl, setFailedUrl] = useState<string | null>(null)
+
+  if (isLoading) {
+    return <Skeleton className="h-[150px] w-[200px] rounded-md" />
+  }
+
+  if (!url) {
+    return <p className="text-muted-foreground text-xs">Attachment not available</p>
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {url !== failedUrl ? (
+        <img
+          src={url}
+          alt="Attachment preview"
+          className="max-h-[200px] max-w-[200px] rounded-md object-contain"
+          onError={() => setFailedUrl(url)}
+        />
+      ) : (
+        <div className="flex items-center gap-2 py-2">
+          <span aria-hidden="true">📄</span>
+          <span className="text-sm">File attachment</span>
+        </div>
+      )}
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary text-xs hover:underline"
+      >
+        View full →
+      </a>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Adds hover-triggered preview to the attachment (📎) icon in the dashboard expenses table
- Uses the `HoverCard` component (Base UI `PreviewCard`) — the purpose-built primitive for hover previews — instead of a Popover with `openOnHover`
- On hover, lazy-loads the attachment URL via `convexQuery(api.storage.getUrl)` with `enabled: isOpen` and shows an image thumbnail (max 200px) or a generic "File attachment" indicator for non-image files
- Overrides `staleTime` (5 min) to prevent stale signed URLs from being served from cache
- Tracks the failed URL instead of a boolean flag so image rendering is retried when a refreshed URL arrives
- Includes a "View full" link that opens the attachment in a new tab
- Uses a `<button>` trigger for keyboard accessibility (focusable via tab)
- 200ms open delay / 150ms close delay for smooth interaction

Closes #125

## Test plan

- [x] `pnpm lint` — no lint errors
- [x] `pnpm build` — clean build (includes `tsc --noEmit`)
- [x] `pnpm test:unit` — all tests pass
- [x] `pnpm test:visual:docker` — no visual regressions
- [ ] CI: e2e tests pass (runs against deployed preview)
- [ ] Verify hovering over 📎 shows a hover card with the image preview after ~200ms
- [ ] Verify non-image attachments show the "📄 File attachment" indicator instead of a broken image
- [ ] Verify the "View full →" link opens the attachment in a new tab
- [ ] Verify hovering away dismisses the hover card after ~150ms delay
- [ ] Verify the attachment URL is only fetched on hover (lazy loading)
- [ ] Verify the skeleton placeholder shows while the URL is loading
- [ ] Verify rows without attachments still show "-" with no hover behavior
- [ ] Verify the attachment trigger is keyboard-focusable