### PR TITLE
feat: add view transitions for page navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -116,6 +116,34 @@
   --radius-4xl: calc(var(--radius) + 16px);
 }
 
+/* View Transitions */
+@media (prefers-reduced-motion: no-preference) {
+  ::view-transition-old(root) {
+    animation: fade-out 150ms ease-in;
+  }
+  ::view-transition-new(root) {
+    animation: fade-in 150ms ease-out;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -94,6 +94,7 @@ function initRouter() {
     createRouter({
       routeTree,
       defaultPreload: 'intent',
+      defaultViewTransition: true,
       context: { queryClient, authStore },
       scrollRestoration: true,
       Wrap: ({ children }) => (


### PR DESCRIPTION
## Summary

- Enable the [View Transitions API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transition_API) for all route navigations via TanStack Router's `defaultViewTransition` option
- Add a subtle 150ms fade-in/fade-out animation on the `::view-transition-old(root)` and `::view-transition-new(root)` pseudo-elements
- Wrap the animations in `@media (prefers-reduced-motion: no-preference)` to respect user accessibility preferences

Closes #126

## Test plan

- [ ] Navigate between pages and verify the fade transition plays
- [ ] Enable "Reduce motion" in OS accessibility settings and confirm no animation occurs
- [ ] Verify the app works correctly in browsers that don't support the View Transitions API (graceful fallback, no errors)

Made with [Cursor](https://cursor.com)