### PR TITLE
Add cursor worktrees setup

### DIFF
--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,7 +1,7 @@
 {
   "setup-worktree-unix": [
     "pnpm install --frozen-lockfile",
-    "test -f \"$ROOT_WORKTREE_PATH/.env.local\" && cp \"$ROOT_WORKTREE_PATH/.env.local\" .env.local || echo 'No .env.local found in main worktree — skipping'",
-    "test -f \"$ROOT_WORKTREE_PATH/.env.e2e\" && cp \"$ROOT_WORKTREE_PATH/.env.e2e\" .env.e2e || echo 'No .env.e2e found in main worktree — skipping'"
+    "test -f \"$ROOT_WORKTREE_PATH/.env.local\" && { test -f .env.local && echo 'Existing .env.local found — keeping local copy' || cp \"$ROOT_WORKTREE_PATH/.env.local\" .env.local; } || echo 'No .env.local found in main worktree — skipping'",
+    "test -f \"$ROOT_WORKTREE_PATH/.env.e2e\" && { test -f .env.e2e && echo 'Existing .env.e2e found — keeping local copy' || cp \"$ROOT_WORKTREE_PATH/.env.e2e\" .env.e2e; } || echo 'No .env.e2e found in main worktree — skipping'"
   ]
 }


### PR DESCRIPTION
## Summary

Adds `.cursor/worktrees.json` to automate initial setup when Cursor creates a new git worktree for parallel agents / best-of-N runs.

The setup script:
- Installs dependencies via `pnpm install --frozen-lockfile`
- Copies `.env.local` and `.env.e2e` from the main worktree (with no-clobber guard to preserve existing copies)

## Test plan
- [x] `pnpm lint` — no lint errors
- [x] `pnpm build` — clean build (includes `tsc --noEmit`)
- [x] `pnpm test:unit` — all tests pass
- [x] CI: e2e tests pass
- [x] Manual worktree simulation: created a temporary worktree, ran the setup commands, verified deps install, env files copy, build succeeds, lint passes, and all 279 unit tests pass