### PR TITLE
feat: change CSV export to Italian format

### DIFF
--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -3,6 +3,7 @@ import {
   formatCurrency,
   formatDate,
   formatDateLong,
+  getItalianMonthName,
   getMonthName,
   parseCurrencyToCents,
   centsToInputValue,
@@ -281,5 +282,38 @@ describe('getMonthName', () => {
   it('returns em dash for non-integer months', () => {
     expect(getMonthName(1.5, 2026)).toBe('—')
     expect(getMonthName(NaN, 2026)).toBe('—')
+  })
+})
+
+describe('getItalianMonthName', () => {
+  it('returns capitalized Italian month names for all 12 months', () => {
+    const expected = [
+      'Gennaio',
+      'Febbraio',
+      'Marzo',
+      'Aprile',
+      'Maggio',
+      'Giugno',
+      'Luglio',
+      'Agosto',
+      'Settembre',
+      'Ottobre',
+      'Novembre',
+      'Dicembre',
+    ]
+    for (let m = 1; m <= 12; m++) {
+      expect(getItalianMonthName(m)).toBe(expected[m - 1])
+    }
+  })
+
+  it('returns em dash for out-of-range months', () => {
+    expect(getItalianMonthName(0)).toBe('—')
+    expect(getItalianMonthName(13)).toBe('—')
+    expect(getItalianMonthName(-1)).toBe('—')
+  })
+
+  it('returns em dash for non-integer months', () => {
+    expect(getItalianMonthName(1.5)).toBe('—')
+    expect(getItalianMonthName(NaN)).toBe('—')
   })
 })

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -128,6 +128,7 @@ export function toISODateString(d: Date): string {
 export const getTodayISO = (): string => toISODateString(new Date())
 
 const monthYearFormatter = new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' })
+const italianMonthFormatter = new Intl.DateTimeFormat('it-IT', { month: 'long' })
 
 /**
  * Get month and year in English (e.g., "January 2026").
@@ -141,4 +142,18 @@ export const getMonthName = (month: number, year: number): string => {
   }
   const date = new Date(year, month - 1, 1)
   return monthYearFormatter.format(date)
+}
+
+/**
+ * Get the Italian month name with first letter capitalized (e.g., "Gennaio").
+ * Returns '—' if month is not an integer between 1 and 12.
+ * @param month - Month number (1-12)
+ */
+export const getItalianMonthName = (month: number): string => {
+  if (!Number.isInteger(month) || month < 1 || month > 12) {
+    return '—'
+  }
+  const date = new Date(2000, month - 1, 1)
+  const name = italianMonthFormatter.format(date)
+  return name.charAt(0).toUpperCase() + name.slice(1)
 }

--- a/src/routes/_authenticated/reports.tsx
+++ b/src/routes/_authenticated/reports.tsx
@@ -14,7 +14,7 @@ import {
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { CSV_BOM, CSV_EOL, csvRow } from '@/lib/csv'
-import { centsToInputValue, formatCurrency, getMonthName } from '@/lib/format'
+import { centsToInputValue, formatCurrency, getItalianMonthName, getMonthName } from '@/lib/format'
 import { extensionFromContentType, promiseAllSettledPooled } from '@/lib/download-utils'
 import { toast } from 'sonner'
 import { Suspense, useState } from 'react'
@@ -162,52 +162,51 @@ function MonthlyReport({ year, month }: { year: number; month: number }) {
 
     setIsDownloadingCsv(true)
     try {
-      // Group expenses by date and category
+      const italianMonth = getItalianMonthName(month)
+
+      // Group expenses by day-of-month and category, summing amounts
       const grouped: Record<string, Record<string, number>> = {}
 
       for (const expense of data.expenses) {
-        if (!grouped[expense.date]) {
-          grouped[expense.date] = {}
+        const day = String(parseInt(expense.date.split('-')[2], 10))
+        if (!grouped[day]) {
+          grouped[day] = {}
         }
-        if (!grouped[expense.date][expense.categoryName]) {
-          grouped[expense.date][expense.categoryName] = 0
+        if (!grouped[day][expense.categoryName]) {
+          grouped[day][expense.categoryName] = 0
         }
-        grouped[expense.date][expense.categoryName] += expense.amount
+        grouped[day][expense.categoryName] += expense.amount
       }
 
-      // Get all unique categories
-      const allCategories = [...new Set(data.expenses.map((e) => e.categoryName))].sort()
+      let csv = csvRow([italianMonth]) + CSV_EOL
+      csv +=
+        csvRow([
+          'giorno',
+          'descrizione',
+          'aliquota',
+          'imponibile',
+          'imposta',
+          'imponibile',
+          'imposta',
+          'totale spese documentate',
+        ]) + CSV_EOL
 
-      let csv = csvRow(['Date', ...allCategories, 'Total']) + CSV_EOL
+      const days = Object.keys(grouped)
+        .map(Number)
+        .sort((a, b) => a - b)
 
-      const dates = Object.keys(grouped).sort()
-      for (const date of dates) {
-        const row = [date]
-        let dayTotal = 0
-
-        for (const category of allCategories) {
-          const amount = grouped[date][category] || 0
-          row.push(centsToInputValue(amount))
-          dayTotal += amount
+      for (const day of days) {
+        const categories = Object.keys(grouped[String(day)]).sort()
+        for (const category of categories) {
+          const amount = grouped[String(day)][category]
+          csv +=
+            csvRow([String(day), category, '', '', '', '', '', centsToInputValue(amount)]) + CSV_EOL
         }
-
-        row.push(centsToInputValue(dayTotal))
-        csv += csvRow(row) + CSV_EOL
       }
 
-      const totalsRow = ['TOTAL']
-      for (const category of allCategories) {
-        const categoryTotal = data.categories[category]?.total || 0
-        totalsRow.push(centsToInputValue(categoryTotal))
-      }
-      totalsRow.push(centsToInputValue(data.total))
-      csv += csvRow(totalsRow) + CSV_EOL
-
-      // Download
       const blob = new Blob([CSV_BOM + csv], { type: 'text/csv;charset=utf-8;' })
-      const monthName = getMonthName(month, year).replace(' ', '-')
       const saveAs = await loadFileSaver()
-      saveAs(blob, `expenses-${monthName}.csv`)
+      saveAs(blob, `expenses-${italianMonth}.csv`)
 
       toast.success('CSV downloaded')
     } catch {


### PR DESCRIPTION
## Summary

- Rewrites the CSV export in the Reports page to use the new Italian format: month name header in Italian, fixed `giorno,descrizione,aliquota,imponibile,imposta,imponibile,imposta,totale spese documentate` columns, expenses grouped by day + category
- Adds `getItalianMonthName()` utility to `src/lib/format.ts` using `Intl.DateTimeFormat('it-IT')`
- Adds unit tests for the new Italian month name function

Closes #178

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:unit` passes (335 tests)
- [ ] Manual verification: download a CSV from the Reports page and confirm the format matches the spec

Made with [Cursor](https://cursor.com)