### PR TITLE
chore(deploy): update wrangler.jsonc compatibility_date to 2026-03-14

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "expense-manager",
-  "compatibility_date": "2025-01-27",
+  "compatibility_date": "2026-03-14",
   "compatibility_flags": ["nodejs_compat"],
   "main": "@tanstack/react-start/server-entry",
 }


### PR DESCRIPTION
## Summary

- Updates `compatibility_date` in `wrangler.jsonc` from `2025-01-27` to `2026-03-14`
- Opts in to all Cloudflare Workers default-on runtime behavior changes shipped between those dates (V8 engine upgrades, new Web APIs, `nodejs_compat` improvements, etc.)

The `compatibility_date` controls which runtime behaviors are active — advancing it enables new default-on behaviors without needing explicit `compatibility_flags` entries.

Closes #176

## Test plan

- [x] `pnpm lint` — no lint errors
- [x] `pnpm build` — clean build
- [x] `pnpm test:unit` — all tests pass
- [x] `pnpm test:visual:docker` — no visual regressions (2 pre-existing dashboard auth timeout failures)
- [x] CI: lint, typecheck, unit tests pass
- [x] CI: preview deploys successfully
- [ ] CI: visual regression tests (blocked by expired Convex deploy key — unrelated to this PR)
- [ ] Verify preview deployment works correctly
- [ ] Verify production deployment works correctly

Made with [Cursor](https://cursor.com)