### PR TITLE
chore(deps): upgrade @hugeicons/core-free-icons 3 → 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@convex-dev/auth": "^0.0.91",
     "@convex-dev/react-query": "^0.1.0",
     "@fontsource-variable/noto-sans": "^5.2.10",
-    "@hugeicons/core-free-icons": "^3.3.0",
+    "@hugeicons/core-free-icons": "^4.0.0",
     "@hugeicons/react": "^1.1.6",
     "@oslojs/crypto": "^1.0.1",
     "@radix-ui/react-slot": "^1.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^5.2.10
         version: 5.2.10
       '@hugeicons/core-free-icons':
-        specifier: ^3.3.0
-        version: 3.3.0
+        specifier: ^4.0.0
+        version: 4.0.0
       '@hugeicons/react':
         specifier: ^1.1.6
         version: 1.1.6(react@19.2.4)
@@ -1097,8 +1097,8 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hugeicons/core-free-icons@3.3.0':
-    resolution: {integrity: sha512-qYyr4JQ2eQIHTSTbITvnJvs6ERNK64D9gpwZnf2IyuG0exzqfyABLO/oTB71FB3RZPfu1GbwycdiGSo46apjMQ==}
+  '@hugeicons/core-free-icons@4.0.0':
+    resolution: {integrity: sha512-bzfbKumv3ke3ajbe2MyXi9i0I/cdsZ6n/mO9EfIPNSL++pHLqs7nSGRIVUtjF4xrrEyVkfhxssv4Jek8DPA6gA==}
 
   '@hugeicons/react@1.1.6':
     resolution: {integrity: sha512-c2LhXJMAW5wN1pC/smBXG0YPqUON6ceR/ZdXHCjEI9KvB+hjtqYjmzIxok5hAQOeXGz0WtORgCQMzqewFKAZwg==}
@@ -5360,7 +5360,7 @@ snapshots:
     dependencies:
       hono: 4.12.7
 
-  '@hugeicons/core-free-icons@3.3.0': {}
+  '@hugeicons/core-free-icons@4.0.0': {}
 
   '@hugeicons/react@1.1.6(react@19.2.4)':
     dependencies:


### PR DESCRIPTION
## Summary

- Bumps `@hugeicons/core-free-icons` from `^3.3.0` to `^4.0.0`
- No source code changes required — v4 re-exports old icon names as backward-compatible aliases
- `@hugeicons/react@1.1.6` has no peer dependency on `core-free-icons`, so fully compatible

Closes #173

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes (includes `tsc --noEmit`)
- [x] `pnpm test:unit` passes (332 tests)
- [ ] Visual spot-check that all icons render correctly

Made with [Cursor](https://cursor.com)