### PR TITLE
fix: match AuthenticatedSkeleton header with its layout

### DIFF
--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/_authenticated')({
 function AuthenticatedSkeleton() {
   return (
     <div className="flex min-h-screen flex-col">
-      <header className="border-b">
+      <header className="bg-background sticky top-0 z-50 border-b">
         <div className="container mx-auto flex items-center justify-between px-4 py-4">
           <Skeleton className="h-6 w-40" />
           <Skeleton className="size-8 rounded-full" />


### PR DESCRIPTION
## Summary

The `AuthenticatedSkeleton` header was missing `bg-background sticky top-0 z-50` compared to its `AuthenticatedLayout` counterpart. This caused:
- A **layout shift** when the pending state resolved (header jumping from static to sticky)
- Content showing through the header if the user scrolled during loading

## Changes

`src/routes/_authenticated.tsx` — added `bg-background sticky top-0 z-50` to the skeleton's `<header>` to match the layout.

## Test plan

- [ ] Verify the authenticated skeleton header is sticky during loading
- [ ] No layout shift when the pending state resolves into the real layout
- [ ] Visual regression tests pass