### PR TITLE
Document Cloudflare custom domain setup

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -219,6 +219,29 @@ pnpm dlx wrangler login
 
 This opens a browser to authenticate your local machine with Cloudflare.
 
+### 2.4 Set Up a Custom Domain
+
+By default, your Worker is accessible at `<worker-name>.<account-subdomain>.workers.dev`. To use your own domain:
+
+1. Go to [Cloudflare Dashboard](https://dash.cloudflare.com/) → **Workers & Pages**
+2. Select your Worker → **Settings** → **Domains & Routes** → **Add** → **Custom Domain**
+3. Enter your domain (e.g., `app.yourdomain.com`) and click **Add Domain**
+
+#### DNS requirements
+
+- The domain (or its parent zone) **must** be on Cloudflare DNS.
+- If the domain is already in your Cloudflare account, Cloudflare creates the required DNS record automatically.
+- If you're using a subdomain of a zone managed elsewhere, add a **proxied CNAME** record pointing to your `workers.dev` subdomain (e.g., `app.yourdomain.com` → `<worker-name>.<account-subdomain>.workers.dev`) and transfer DNS management for that zone to Cloudflare.
+
+#### Verification
+
+1. After adding the custom domain, the dashboard shows a status of **Active** once DNS propagation completes (usually under a minute for zones already on Cloudflare).
+2. Confirm the domain resolves to your Worker:
+   ```bash
+   curl -sI https://app.yourdomain.com | head -5
+   ```
+3. Update the production **site URL** in your Convex auth configuration (step 1.5) to match the new domain.
+
 ---
 
 ## 3. GitHub Repository Setup


### PR DESCRIPTION
## Summary

- Adds a new **§ 2.4 Set Up a Custom Domain** subsection to `docs/SETUP.md` under the Cloudflare setup section.
- Covers adding a custom domain via the Cloudflare dashboard, DNS requirements, and verification steps.

Closes #203

## Test plan

- [ ] Verify the new section renders correctly in the GitHub Markdown preview.
- [ ] Confirm numbered steps and formatting are consistent with the rest of `docs/SETUP.md`.

Made with [Cursor](https://cursor.com)