### PR TITLE
Add E2E test for Settings page title

### DIFF
--- a/e2e/page-titles.spec.ts
+++ b/e2e/page-titles.spec.ts
@@ -50,6 +50,13 @@ test.describe('Page titles — authenticated routes', () => {
     await expect(page).toHaveTitle('Reports — Expense Manager')
   })
 
+  test('settings page has descriptive title', async ({ page }) => {
+    await page.getByRole('link', { name: /settings/i }).click()
+    await page.waitForURL('**/settings')
+
+    await expect(page).toHaveTitle('Settings — Expense Manager')
+  })
+
   test('new expense page has descriptive title', async ({ page }) => {
     await page.getByRole('link', { name: /new expense/i }).click()
     await page.waitForURL('**/expenses/new')


### PR DESCRIPTION
## Summary

- Adds an E2E test verifying the Settings page title is `Settings — Expense Manager`
- Follows the same pattern as the existing reports page title test

**Note:** The attachment replacement test that was previously part of this PR was landed independently via #209.

## Test plan

- [x] `pnpm lint` — no lint errors
- [x] `pnpm build` — clean build (includes `tsc --noEmit`)
- [x] `pnpm test:unit` — all tests pass
- [x] `pnpm test:visual:docker` — no visual regressions
- [ ] CI: e2e tests pass (runs against deployed preview)

Closes #194