### PR TITLE
Add unit tests for reports CSV/ZIP helper functions

### DIFF
--- a/src/__tests__/reports-lib.test.ts
+++ b/src/__tests__/reports-lib.test.ts
@@ -2,13 +2,16 @@ import { describe, it, expect } from 'vitest'
 import { buildCsvContent, buildZipFilename } from '@/lib/reports'
 import { CSV_BOM, CSV_EOL } from '@/lib/csv'
 
+function csvLines(result: string): string[] {
+  expect(result.startsWith(CSV_BOM)).toBe(true)
+  return result.slice(CSV_BOM.length).split(CSV_EOL)
+}
+
 describe('buildCsvContent', () => {
   const headerRow = `giorno,descrizione,aliquota,imponibile,imposta,imponibile,imposta,totale spese documentate`
 
   it('returns BOM-prefixed CSV with Italian month header', () => {
-    const result = buildCsvContent([], 1)
-    expect(result.startsWith(CSV_BOM)).toBe(true)
-    const lines = result.slice(CSV_BOM.length).split(CSV_EOL)
+    const lines = csvLines(buildCsvContent([], 1))
     expect(lines[0]).toBe('Gennaio')
   })
 
@@ -17,11 +20,11 @@ describe('buildCsvContent', () => {
       { date: '2026-01-05', categoryName: 'Food', amount: 1000 },
       { date: '2026-01-05', categoryName: 'Food', amount: 2500 },
     ]
-    const result = buildCsvContent(expenses, 1)
-    const lines = result.slice(CSV_BOM.length).split(CSV_EOL)
+    const lines = csvLines(buildCsvContent(expenses, 1))
     expect(lines[0]).toBe('Gennaio')
     expect(lines[1]).toBe(headerRow)
     expect(lines[2]).toBe('5,Food,,,,,,35.00')
+    expect(lines).toHaveLength(4)
   })
 
   it('sorts rows by day ascending, then category alphabetically', () => {
@@ -31,19 +34,18 @@ describe('buildCsvContent', () => {
       { date: '2026-03-03', categoryName: 'Accommodation', amount: 700 },
       { date: '2026-03-15', categoryName: 'Food', amount: 1200 },
     ]
-    const result = buildCsvContent(expenses, 3)
-    const lines = result.slice(CSV_BOM.length).split(CSV_EOL)
+    const lines = csvLines(buildCsvContent(expenses, 3))
     expect(lines[0]).toBe('Marzo')
     expect(lines[1]).toBe(headerRow)
     expect(lines[2]).toBe('3,Accommodation,,,,,,7.00')
     expect(lines[3]).toBe('3,Drinks,,,,,,3.00')
     expect(lines[4]).toBe('15,Food,,,,,,12.00')
     expect(lines[5]).toBe('15,Transport,,,,,,5.00')
+    expect(lines).toHaveLength(7)
   })
 
   it('returns only header rows when expenses array is empty', () => {
-    const result = buildCsvContent([], 7)
-    const lines = result.slice(CSV_BOM.length).split(CSV_EOL)
+    const lines = csvLines(buildCsvContent([], 7))
     expect(lines[0]).toBe('Luglio')
     expect(lines[1]).toBe(headerRow)
     expect(lines[2]).toBe('')
@@ -51,20 +53,36 @@ describe('buildCsvContent', () => {
   })
 
   it('handles a single expense', () => {
-    const expenses = [{ date: '2026-12-25', categoryName: 'Gifts', amount: 5000 }]
-    const result = buildCsvContent(expenses, 12)
-    const lines = result.slice(CSV_BOM.length).split(CSV_EOL)
+    const lines = csvLines(
+      buildCsvContent([{ date: '2026-12-25', categoryName: 'Gifts', amount: 5000 }], 12),
+    )
     expect(lines[0]).toBe('Dicembre')
     expect(lines[1]).toBe(headerRow)
     expect(lines[2]).toBe('25,Gifts,,,,,,50.00')
+    expect(lines).toHaveLength(4)
   })
 
   it('handles expenses with special characters in category name', () => {
-    const expenses = [{ date: '2026-02-10', categoryName: 'Food, Drinks & More', amount: 1500 }]
-    const result = buildCsvContent(expenses, 2)
-    const lines = result.slice(CSV_BOM.length).split(CSV_EOL)
+    const lines = csvLines(
+      buildCsvContent(
+        [{ date: '2026-02-10', categoryName: 'Food, Drinks & More', amount: 1500 }],
+        2,
+      ),
+    )
     expect(lines[0]).toBe('Febbraio')
+    expect(lines[1]).toBe(headerRow)
     expect(lines[2]).toBe('10,"Food, Drinks & More",,,,,,15.00')
+    expect(lines).toHaveLength(4)
+  })
+
+  it('prefixes formula-triggering category names with apostrophe', () => {
+    const lines = csvLines(
+      buildCsvContent([{ date: '2026-04-01', categoryName: '-Discount', amount: 800 }], 4),
+    )
+    expect(lines[0]).toBe('Aprile')
+    expect(lines[1]).toBe(headerRow)
+    expect(lines[2]).toBe("1,'-Discount,,,,,,8.00")
+    expect(lines).toHaveLength(4)
   })
 })
 


### PR DESCRIPTION
## Summary
- Adds unit tests for `buildCsvContent` and `buildZipFilename` in `src/lib/reports.ts`
- Tests cover grouping, sorting, deduplication, sanitization, formula-injection mitigation, and edge cases
- Originally stacked on #210 (now merged); rebased directly onto `main`

## Test plan
- [x] All new tests pass with `pnpm test:unit`
- [x] `pnpm lint` passes
- [x] `pnpm build` (includes `tsc --noEmit`) passes
- [x] `pnpm test:visual:docker` passes (43 passed, 1 skipped)

Closes #195

Made with [Cursor](https://cursor.com)