### PR TITLE
Add explicit permissions to CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -11,6 +11,9 @@ concurrency:
   group: convex-test-deploy
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-visual.yml
+++ b/.github/workflows/test-visual.yml
@@ -11,6 +11,9 @@ concurrency:
   group: convex-test-deploy
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   visual:
     runs-on: ubuntu-latest

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds explicit `permissions: { contents: read }` to 6 CI workflows that previously inherited default repo permissions
- Follows the principle of least privilege for GitHub Actions
- No functional changes to workflow behavior

Workflows updated: test-e2e, typecheck, lint, test-unit, test-visual, deploy

Closes #218

Made with [Cursor](https://cursor.com)