### PR TITLE
Add console.error to reports download catch blocks

### DIFF
--- a/src/routes/_authenticated/reports.tsx
+++ b/src/routes/_authenticated/reports.tsx
@@ -169,7 +169,8 @@ function MonthlyReport({ year, month }: { year: number; month: number }) {
       saveAs(blob, `expenses-${getItalianMonthName(month)}.csv`)
 
       toast.success('CSV downloaded')
-    } catch {
+    } catch (error) {
+      console.error('CSV generation failed:', error)
       toast.error('Error generating CSV')
     } finally {
       setIsDownloadingCsv(false)
@@ -261,7 +262,8 @@ function MonthlyReport({ year, month }: { year: number; month: number }) {
       } else {
         toast.success(`ZIP downloaded (${successfulDownloads} ${fileLabel})`)
       }
-    } catch {
+    } catch (error) {
+      console.error('ZIP generation failed:', error)
       toast.error('Error generating ZIP')
     } finally {
       setIsDownloadingZip(false)


### PR DESCRIPTION
## Summary
- Adds `console.error` to the CSV and ZIP download error handlers in the reports page
- Previously, errors were caught and a toast shown but the actual error was discarded
- Now errors are logged to the console for debugging while maintaining the user-facing toast

Closes #221

Made with [Cursor](https://cursor.com)