### PR TITLE
fix(dashboard): cancel previous page query before optimistic isDone update

### DIFF
--- a/src/routes/_authenticated/dashboard.tsx
+++ b/src/routes/_authenticated/dashboard.tsx
@@ -167,6 +167,10 @@ function ExpenseTable() {
           cursor: prevCursor,
           limit: pageSize,
         }).queryKey
+        // Cancel any in-flight fetches / reactive subscription pushes
+        // for the previous page so they don't overwrite our optimistic
+        // isDone before the server-side mutation commits.
+        await queryClient.cancelQueries({ queryKey: prevQueryKey })
         previousPageEntry = {
           queryKey: prevQueryKey,
           data: queryClient.getQueryData(prevQueryKey),


### PR DESCRIPTION
## Summary

- Fixes the consistently failing E2E test on `main`: **"auto-navigates back when last item on a later page is deleted"** (`dashboard-pagination.spec.ts:12`)
- The `onMutate` optimistic update already sets `isDone: true` on the previous page's cache when navigating back after deletion, but the previous page's Convex reactive subscription was **not cancelled** — allowing a stale server push (`isDone: false`) to overwrite the optimistic value before the mutation commits
- Adds `cancelQueries` for the previous page's query key before writing the optimistic `isDone`, mirroring the existing `cancelQueries` call for the current page (line 147)

## Root cause

When the only item on page 2 is deleted:

1. `onMutate` cancels page 2's query and optimistically removes the expense
2. It detects the empty page and sets `isDone: true` on page 1's cache
3. It pops the cursor stack to navigate back to page 1

But between steps 2 and the mutation committing server-side, Convex's reactive subscription for page 1 can push a stale update (11 expenses still exist → `isDone: false`), overwriting the optimistic value. The "Next" button flickers back to enabled, and the E2E assertion `toBeDisabled()` catches this intermediate state.

## Fix

```diff
       if (previousCursors) {
         const prevCursor = cursors[cursors.length - 2]
         const prevQueryKey = convexQuery(api.expenses.list, {
           cursor: prevCursor,
           limit: pageSize,
         }).queryKey
+        await queryClient.cancelQueries({ queryKey: prevQueryKey })
         previousPageEntry = {
```

This ensures no in-flight or reactive updates for the previous page can overwrite our optimistic state. The `onSettled` handler's `invalidateQueries` (with `exact: false`) will trigger a fresh refetch once the mutation has committed, at which point the server correctly returns `isDone: true`.

## Test plan

- [ ] E2E test "auto-navigates back when last item on a later page is deleted" passes in CI (was failing on every run)
- [ ] Other E2E tests remain green
- [ ] Lint and type-check pass

Made with [Cursor](https://cursor.com)