### PR TITLE
fix(ci): add retry loop to deploy gate for API consistency lag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,13 @@ jobs:
               'Integration Tests',
             ];
 
+            // The deploy workflow fires on workflow_run:completed for each CI
+            // workflow.  The Actions API sometimes lags behind by a few seconds
+            // before a just-completed run shows up in status:completed queries,
+            // so we poll with a short back-off instead of checking once.
+            const MAX_ATTEMPTS = 5;
+            const RETRY_DELAY_MS = 30_000;
+
             // Only deploy the commit currently at the tip of main.
             // Re-running stale CI checks must not roll back production.
             const { data: { commit: { sha: mainSha } } } = await github.rest.repos.getBranch({
@@ -46,31 +53,49 @@ jobs:
               return;
             }
 
-            // Scope to push-triggered runs on main so PR runs for the
-            // same SHA cannot satisfy the gate.
-            const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRunsForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              head_sha: sha,
-              branch: 'main',
-              event: 'push',
-              status: 'completed',
-              per_page: 100,
-            });
+            let allGreen = false;
+            let results;
 
-            const latestByName = new Map();
-            for (const run of runs) {
-              const prev = latestByName.get(run.name);
-              if (!prev || new Date(run.created_at) > new Date(prev.created_at)) {
-                latestByName.set(run.name, run);
+            for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+              // Scope to push-triggered runs on main so PR runs for the
+              // same SHA cannot satisfy the gate.
+              const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head_sha: sha,
+                branch: 'main',
+                event: 'push',
+                status: 'completed',
+                per_page: 100,
+              });
+
+              const latestByName = new Map();
+              for (const run of runs) {
+                const prev = latestByName.get(run.name);
+                if (!prev || new Date(run.created_at) > new Date(prev.created_at)) {
+                  latestByName.set(run.name, run);
+                }
               }
-            }
 
-            const results = required.map(name => ({
-              name,
-              conclusion: latestByName.get(name)?.conclusion ?? 'missing',
-            }));
-            const allGreen = results.every(r => r.conclusion === 'success');
+              results = required.map(name => ({
+                name,
+                conclusion: latestByName.get(name)?.conclusion ?? 'missing',
+              }));
+              allGreen = results.every(r => r.conclusion === 'success');
+
+              const missing = results.filter(r => r.conclusion !== 'success');
+              core.info(
+                `Attempt ${attempt}/${MAX_ATTEMPTS} — ` +
+                `API returned ${runs.length} completed run(s) [${[...new Set(runs.map(r => r.name))].join(', ')}] — ` +
+                (allGreen
+                  ? 'all required workflows green'
+                  : `waiting on: ${missing.map(r => `${r.name} (${r.conclusion})`).join(', ')}`)
+              );
+
+              if (allGreen || attempt === MAX_ATTEMPTS) break;
+
+              await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+            }
 
             core.summary.addHeading('CI Gate', 3);
             core.summary.addTable([


### PR DESCRIPTION
## Problem

Commits merged to `main` pass all CI checks but are never deployed to production. The issue was first noticed on commit `9ea0217` (PR #240) and confirmed to also affect the previous commit `fbf557d`.

### Root cause

The `Deploy` workflow fires on `workflow_run: completed` — once for **each** of the four required CI workflows. Each firing triggers the `gate` job, which queries the Actions API (`listWorkflowRunsForRepo` with `status: completed`) to check whether all four required workflows are green.

Due to **GitHub API eventual-consistency lag**, recently-completed runs sometimes don't appear in the filtered response yet. The gate sees fewer than 4 green workflows and sets `should-deploy` to `false`, skipping the deploy. By the time all four CI workflows have completed and the API has caught up, no more `workflow_run` events fire to re-trigger the gate.

Evidence: querying the same API endpoint *after the fact* returns all four workflows as `success`, confirming the data was correct but not yet propagated when the gate checked.

## Fix

Add a **polling loop** (5 attempts, 30 s apart — fits within the existing 5-min gate timeout) so the gate waits for the API to catch up instead of failing on the first check.

Each attempt now logs:
- The number and names of completed runs returned by the API
- Which required workflows are still missing or non-green

This makes future gate failures diagnosable from the job logs without forensic investigation.

## Test plan

- [ ] Merge this PR and verify the next commit to `main` triggers a successful deployment
- [ ] Check the `gate` job logs to confirm retry logging appears as expected
- [ ] If the gate still fails after all 5 attempts, the detailed logging will reveal whether the issue is API lag or something else (e.g., a workflow name mismatch)

Made with [Cursor](https://cursor.com)